### PR TITLE
fix: localhostに対する動的ポートバインドエラーを修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,6 @@ node_modules/
 dist/
 coverage/
 .env
-
+.next/
+out/
+build/

--- a/backend/Properties/launchSettings.json
+++ b/backend/Properties/launchSettings.json
@@ -1,10 +1,10 @@
-﻿{
+{
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "iisSettings": {
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:0",
+      "applicationUrl": "http://localhost:5000",
       "sslPort": 0
     }
   },
@@ -14,7 +14,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "http://localhost:0",
+      "applicationUrl": "http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -24,7 +24,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "https://localhost:0;http://localhost:0",
+      "applicationUrl": "https://localhost:5001;http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.


### PR DESCRIPTION
## 概要
ローカル開発環境にてバックエンド（`dotnet run`）が起動できない不具合を修正しました。
Issue: #1 

## 変更内容
- `backend/Properties/launchSettings.json` を修正
  - `applicationUrl` に指定されていた動的ポート設定（`:0`）を、固定ポート設定（`:5000`）に変更しました。
  - `http` および `https`（存在する場合）の両プロファイルに対して修正を適用しています。

## 動作確認手順
1. 本ブランチをチェックアウトする。
2. `backend` ディレクトリに移動し、`dotnet run` を実行する。
3. 例外が発生せず、正常にアプリケーションが起動し `http://localhost:5000` 等でリッスン状態になることを確認する。
